### PR TITLE
conditional footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -5,7 +5,9 @@
       Built with <a target="_blank" rel="noopener noreferrer" href="https://www.getzola.org">Zola</a> using <a target="_blank" rel="noopener noreferrer" href="https://github.com/Speyll/anemone">anemone</a> theme &amp; <a target="_blank" rel="noopener noreferrer" href="https://github.com/Speyll/veqev">veqev</a> colors.<br>
     </p>
   </div>
+  {% if config.generate_feed %}
   <div class="footRight">
     <a class="icons__background" target="_blank" rel="noopener noreferrer" href="{{ get_url(path="atom.xml", trailing_slash=false) }}" title="Subscribe via RSS for updates."><svg class="icons icons__background"><use href="{{ get_url(path='icons.svg#rss', trailing_slash=false) | safe }}"></use></svg></a>
   </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
This will get rid of the signal icon of the footer if generate_feed is false

I'm not sure how the atom.xml is supposed to be created but I assume it's only when you generate feed. It then looks like this

![image](https://github.com/Speyll/anemone/assets/53686698/a1e95158-e963-4e5c-831d-aefbe60c8b9a)
