### PR TITLE
Add author to blog-page，add default_mode to choose light or dark mode

### DIFF
--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -3,42 +3,43 @@
 {% block content %}
 <div><a href="..">..</a>/<span class="metaData">{{ page.slug }}</span></div>
 <time datetime="{{ page.date }}">Published on: <span class="metaData">{{ page.date }}</span></time>
+<address rel="author">By <span class="metaData">{{config.extra.author}}</span></address>
 <h1>{{ page.title }}</h1>
 
 {% if page.toc and page.extra.toc %}
 <h2>Table of contents</h2>
 <ul>
-{% for h1 in page.toc %}
+  {% for h1 in page.toc %}
   <li>
-  <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
-  {% if h1.children %}
+    <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
+    {% if h1.children %}
     <ul>
       {% for h2 in h1.children %}
-        <li>
+      <li>
         <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
-          <ul>
+        <ul>
           {% for h3 in h2.children %}
-            <li>
+          <li>
             <a href="{{ h3.permalink | safe }}">{{ h3.title }}</a>
-            </li>
+          </li>
           {% endfor %}
-          </ul>
-        </li>
+        </ul>
+      </li>
       {% endfor %}
     </ul>
-  {% endif %}
+    {% endif %}
   </li>
-{% endfor %}
+  {% endfor %}
 </ul>
 {% endif %}
 
 {{ page.content | safe }}
 
 <p class="tagsData">
-{% if page.taxonomies.tags %}
-{% for tag in page.taxonomies.tags %}
-<a href="/tags/{{ tag | slugify }}">&#47;{{ tag }}&#47;</a>
-{% endfor %}
-{% endif %}
+  {% if page.taxonomies.tags %}
+  {% for tag in page.taxonomies.tags %}
+  <a href="/tags/{{ tag | slugify }}">&#47;{{ tag }}&#47;</a>
+  {% endfor %}
+  {% endif %}
 </p>
 {% endblock content %}

--- a/templates/header.html
+++ b/templates/header.html
@@ -3,23 +3,50 @@
   {% for nav_item in config.extra.header_nav %}
   {% set current_nav_item = nav_item[lang] %}
   {% if current_nav_item and current_nav_item.name %}
-  <a href="{{ get_url(path=current_nav_item.url) }}" {% if current_nav_item.new_tab %}target="_blank" rel="noreferrer noopener"{% endif %}>{{ current_nav_item.name }}</a>
+  <a href="{{ get_url(path=current_nav_item.url) }}" {% if current_nav_item.new_tab %}target="_blank"
+    rel="noreferrer noopener" {% endif %}>{{ current_nav_item.name }}</a>
   {% endif %}
   {% endfor %}
   <div class="themeSwitch">
-    <button class="themeButton light" onclick="setTheme('light')" title="Light mode"><svg class="icons icons__background"><use href="{{ get_url(path='icons.svg#lightMode', trailing_slash=false) | safe }}"></use></svg></button>
-    <button class="themeButton dark" onclick="setTheme('dark')" title="Dark mode"><svg class="icons icons__background"><use href="{{ get_url(path='icons.svg#darkMode', trailing_slash=false) | safe }}"></use></svg></button>
+    {% if not config.extra.default_mode %}
+    <button class="themeButton light" onclick="setTheme('light')" title="Light mode"><svg
+        class="icons icons__background">
+        <use href="{{ get_url(path='icons.svg#lightMode', trailing_slash=false) | safe }}"></use>
+      </svg></button>
+    <button class="themeButton dark" onclick="setTheme('dark')" title="Dark mode"><svg class="icons icons__background">
+        <use href="{{ get_url(path='icons.svg#darkMode', trailing_slash=false) | safe }}"></use>
+      </svg></button>
+    {% elif config.extra.default_mode and config.extra.default_mode == "light" %}
+    <button class="themeButton light" onclick="setTheme('light')" title="Light mode"><svg
+        class="icons icons__background">
+        <use href="{{ get_url(path='icons.svg#lightMode', trailing_slash=false) | safe }}"></use>
+      </svg></button>
+    <button class="themeButton dark" onclick="setTheme('dark')" title="Dark mode"><svg class="icons icons__background">
+        <use href="{{ get_url(path='icons.svg#darkMode', trailing_slash=false) | safe }}"></use>
+      </svg></button>
+    {% elif config.extra.default_mode and config.extra.default_mode == "dark" %}
+    <button class="themeButton dark" onclick="setTheme('dark')" title="Dark mode"><svg class="icons icons__background">
+        <use href="{{ get_url(path='icons.svg#darkMode', trailing_slash=false) | safe }}"></use>
+      </svg></button>
+    <button class="themeButton light" onclick="setTheme('light')" title="Light mode"><svg
+        class="icons icons__background">
+        <use href="{{ get_url(path='icons.svg#lightMode', trailing_slash=false) | safe }}"></use>
+      </svg></button>
+    {% endif %}
   </div>
 </nav>
 {% endif %}
 <script>
   const setTheme = (theme) => {
-      document.documentElement.className = theme;
-      localStorage.setItem('theme', theme);
+    document.documentElement.className = theme;
+    localStorage.setItem('theme', theme);
   }
   const getTheme = () => {
-      const theme = localStorage.getItem('theme');
-      theme && setTheme(theme);
+    const theme = localStorage.getItem('theme');
+    theme && setTheme(theme);
   }
   getTheme()
+  {% if config.extra.default_mode %}
+  setTheme("{{ config.extra.default_mode }}")
+  {% endif %}
 </script>


### PR DESCRIPTION
In this pull request, I made two changes to the config file config.toml.

First, I added the author field from the [extra] section to the blog-page.html template so that the author name is displayed on blog posts.

Second, I added a default_mode field to the [extra] section to allow choosing whether the website opens in light or dark mode by default.

These changes will display the post author name and allow configuring the default display mode.

Please note that English is not my native language, so I used an AI assistant to help translate this content. I apologize if any parts are unclear due to translation. Please let me know if you need any clarification or have suggestions to improve the description. Any feedback is appreciated as I continue working to improve my English writing abilities.

Thank you for reviewing these changes!