### PR TITLE
Added optional generation of div in footer to display content license…

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ toc = true
 - Set the `author` in both the main config and in pages' metadata.
 - Use the `image` variable in pages to add an image to HTML `<meta>` tags.
 - Similarly, set `favicon` in the main config, and it will be used as the site icon.
-- Set `footer_content_license` and `footer_content_license_link` if you wish to display conent license information in the footer.
+- Set `footer_content_license` and `footer_content_license_link` if you wish to display content license information in the footer.
 
 #### Disable Twitter Card
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ toc = true
 - Set the `author` in both the main config and in pages' metadata.
 - Use the `image` variable in pages to add an image to HTML `<meta>` tags.
 - Similarly, set `favicon` in the main config, and it will be used as the site icon.
+- Set `footer_content_license` and `footer_content_license_link` if you wish to display conent license information in the footer.
 
 #### Disable Twitter Card
 

--- a/config.toml
+++ b/config.toml
@@ -46,3 +46,7 @@ header_nav = [
   { url = "/journal", name_en = "/journal/", name_fr = "/journal/" },
   { url = "/blog", name_en = "/blog/", name_fr = "/blog/" }
 ]
+
+# Optional footer license text. It will only show, when using footer_content_license.
+#footer_content_license = "Creative Commons Attribution 4.0 International"
+#footer_content_license_link = "https://creativecommons.org/licenses/by/4.0/"

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -10,7 +10,7 @@
     license.</div>
   {% endif %}
   <div class="footLeft">
-    <p>Theme and color theme licensed under <a target="_blank" rel="noopener noreferrer" href="https://fr.wikipedia.org/wiki/Licence_MIT">MIT</a><br>
+    <p>Theme and color theme licensed under <a target="_blank" rel="noopener noreferrer" href="https://fr.wikipedia.org/wiki/Licence_MIT">MIT</a>.<br>
       Built with <a target="_blank" rel="noopener noreferrer" href="https://www.getzola.org">Zola</a> using <a target="_blank" rel="noopener noreferrer" href="https://github.com/Speyll/anemone">anemone</a> theme &amp; <a target="_blank" rel="noopener noreferrer" href="https://github.com/Speyll/veqev">veqev</a> colors.<br>
     </p>
   </div>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,7 +1,16 @@
 <hr>
 <div class=footContainer>
+  {% if config.extra.footer_content_license %}
+    <div>Except where otherwise noted, content on this site is licensed under a 
+    {% if config.extra.footer_content_license_link %}
+    <a target="_blank" rel="noopener noreferrer" href="{{config.extra.footer_content_license_link}}">{{config.extra.footer_content_license}}</a>
+    {% else %}
+    {{config.extra.footer_content_license}}
+    {% endif %}
+    license.</div>
+  {% endif %}
   <div class="footLeft">
-    <p>Licensed under <a target="_blank" rel="noopener noreferrer" href="https://fr.wikipedia.org/wiki/Licence_MIT">MIT</a><br>
+    <p>Theme and color theme licensed under <a target="_blank" rel="noopener noreferrer" href="https://fr.wikipedia.org/wiki/Licence_MIT">MIT</a><br>
       Built with <a target="_blank" rel="noopener noreferrer" href="https://www.getzola.org">Zola</a> using <a target="_blank" rel="noopener noreferrer" href="https://github.com/Speyll/anemone">anemone</a> theme &amp; <a target="_blank" rel="noopener noreferrer" href="https://github.com/Speyll/veqev">veqev</a> colors.<br>
     </p>
   </div>


### PR DESCRIPTION
This adds an optional footer text when specifying `footer_content_license` (and `footer_content_license_link`).

It reads something like this (just like [cc](https://creativecommons.org/) does it):
"Except where otherwise noted, content on this site is licensed under a `footer_content_license` license."

![anamaaaaaa](https://github.com/Speyll/anemone/assets/100924950/6e63b9ce-62ee-4c34-a77d-89cde9098fc5)

I also added that the theme and color theme are licensed under MIT. I  think that else it is missleading. 

closes #19 