### PR TITLE
Rename `generate_feed` into `generate_feeds` as per Zola 0.19 breaking changes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ title = "anemone"
 description = "A minimalist Zola theme that prioritizes clean CSS and avoids heavy JavaScript. Enjoy a seamless user experience with lightning-fast load times. Let your content take center stage in a clutter-free, elegant design that enhances readability. Responsive and efficient, anemone brings focus to your ideas."
 compile_sass = false
 minify_html = true
-generate_feed = true
+generate_feeds = true
 default_language = "en"
 
 taxonomies = [

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -15,7 +15,7 @@
     </p>
 
   </div>
-  {% if config.generate_feed %}
+  {% if config.generate_feeds %}
   <div>
     <a class="no-style" target="_blank" rel="noopener noreferrer" href="{{ get_url(path="atom.xml", trailing_slash=false) }}" title="Subscribe via RSS for updates."><svg class="icons"><use href="{{ get_url(path='icons.svg#rss', trailing_slash=false) | safe }}"></use></svg></a>
   </div>

--- a/templates/head.html
+++ b/templates/head.html
@@ -84,7 +84,7 @@
 <link rel="shortcut icon" type="image/x-icon" href="{{ get_url(path=config.extra.favicon, trailing_slash=false) }}">
 {% endif %}
 {% endblock metatags %}
-{% if config.generate_feed %}
+{% if config.generate_feeds %}
 {% block feed %}
 <link rel="alternate" type="application/atom+xml" title="RSS" href="{{ get_url(path="atom.xml", trailing_slash=false) }}"> 
 {% endblock feed %}


### PR DESCRIPTION
# Current behavior

When building a site with Zola and this theme, or even just running `zola check`, it currently fails with the following:

```
Checking site...
Error: Failed to check the site
Error: TOML parse error at line 11, column 1
   |
11 | generate_feed = true
   | ^^^^^^^^^^^^^
unknown field `generate_feed`, expected one of `base_url`, `theme`, `title`, `description`, `default_language`, `languages`, `translations`, `generate_feeds`, `feed_limit`, `feed_filenames`, `hard_link_static`, `taxonomies`, `author`, `compile_sass`, `minify_html`, `build_search_index`, `ignored_content`, `ignored_static`, `mode`, `output_dir`, `preserve_dotfiles_in_output`, `link_checker`, `slugify`, `search`, `markdown`, `extra`
```

# Explanation

As part of the [Zola `0.19` release](https://github.com/getzola/zola/releases/tag/v0.19.0), the support for multiple feeds (Atom, RSS) was added (https://github.com/getzola/zola/pull/2477). This resulted in the renaming of the `generate_feed` top level configuration key of Zola into `generate_feeds` (note the `+s`).

When coupled with the [introduction](https://github.com/getzola/zola/pull/2477/files#diff-a73b136cfeff938999478a03e6175bc37817735163284f8e5de491cbf5bab771R33) of `#[serde(deny_unknown_fields)]` on the Zola configuration validation that was shipped at the same time, it not only means that the old name is no longer effective, but that it's now actually denied.

Also see https://github.com/getzola/zola/issues/2566 for the upstream discussion.

# Fix

This PR proposes to fix that by renaming all the occurrences of `generate_feed` into `generate_feeds` :slightly_smiling_face: 

Tested locally and it works fine.