### PR TITLE
Remove `path` frontmatter on section as per Zola 0.19 breaking changes

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,6 +1,5 @@
 +++
 paginate_by = 15
-path = "blog"
 title = "All blog posts"
 sort_by = "date"
 page_template = "blog-page.html"


### PR DESCRIPTION
# Current behavior

When building a site with Zola and this theme along with the sample/demo content, or even just running `zola check` on such a setup, it currently fails with the following:

```
Checking site...
Error: Failed to check the site
Error: Error when parsing front matter of section `/home/horgix/projects/blog/content/blog/_index.md`
Error: Reason: TOML parse error at line 3, column 1
  |
3 | path = "blog"
  | ^^^^
unknown field `path`, expected one of `title`, `description`, `sort_by`, `weight`, `draft`, `template`, `paginate_by`, `paginate_reversed`, `paginate_path`, `insert_anchor_links`, `render`, `redirect_to`, `in_search_index`, `transparent`, `page_template`, `aliases`, `generate_feeds`, `extra`
```

# Explanation

The [Zola `0.19` release](https://github.com/getzola/zola/releases/tag/v0.19.0), along with other changes, [introduced](https://github.com/getzola/zola/pull/2477/files#diff-a73b136cfeff938999478a03e6175bc37817735163284f8e5de491cbf5bab771R33) `#[serde(deny_unknown_fields)]` on the Zola configuration validation.

It also turns out that the `path` key in the Zola files frontmatter is only valid for _files_ and not for _sections_ :

From https://www.getzola.org/documentation/content/overview/ (emphasis and ellipsis mine):
> You might have noticed a file named **`_index.md`** [...]. This file is used to store both the metadata and content of the section itself and i**s not considered a page**.

And indeed, the `path` frontmatter key is only documented on **pages**: https://www.getzola.org/documentation/content/page/#front-matter.

_Also see https://github.com/getzola/zola/issues/2566#issuecomment-2209552725 for the upstream discussion._

# Fix

This PR proposes to fix that by simply removing the `path` configuration on the `blog/` section configuration  :slightly_smiling_face: 

Tested locally and it works fine.