### PR TITLE
Disable unused search index

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@ taxonomies = [
 
 [languages.fr]
 generate_feeds = true
-build_search_index = true
+build_search_index = false
 
 [markdown]
 render_emoji = true


### PR DESCRIPTION
This disables the building of the currently unused search index.

This will result in a slightly faster build as well as less unused files generated.