### PR TITLE
Fix default favicon path in base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="{{ get_url(path='css/custom.css') }}">
 
         <!-- Add favicon with appropriate sizes -->
-        <link rel="icon" href="{{ config.extra.favicon | default(value='/favicon.ico') }}">
+        <link rel="icon" href="{{ config.extra.favicon | default(value='favicon.ico') }}">
     </head>
     <body>
         {% set current_lang = config.default_language %}


### PR DESCRIPTION
The favicon element looks like this on the generated site: `<link rel="icon" href="&amp;#x2F;favicon.ico">` due to the leading "/" in the default favicon path in the `base.html` template.

This PR removes that slash and changes the default favicon element back to `<link rel="icon" href="favicon.ico">` as expected.