### PR TITLE
Get css from github

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,8 @@
         <title>{{ config.title }}{% if page.title %} | {{ page.title }}{% endif %}</title>
 
         <link rel="preload" href="{{ get_url(path='css/style.css') }}" as="style">
-        <link rel="stylesheet" href="https://raw.githack.com/Speyll/suCSS/main/reset-min.css" crossorigin="anonymous">
-        <link rel="stylesheet" href="https://raw.githack.com/Speyll/suCSS/main/suCSS-min.css" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://speyll.github.io/suCSS/reset-min.css" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://speyll.github.io/suCSS/suCSS-min.css" crossorigin="anonymous">
         <link rel="stylesheet" href="{{ get_url(path='css/style.css') }}">
         <link rel="stylesheet" href="{{ get_url(path='css/custom.css') }}">
 


### PR DESCRIPTION
[GitHack](https://raw.githack.com/) has been down all day, preventing the anemone theme from loading. This pr changes the `base.html` template to get the css from github (as described in the [suCSS README](https://github.com/Speyll/suCSS/blob/main/README.md)) instead of githack.