### PR TITLE
Added multilingual linking in navigation bar with fallback

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,8 +48,8 @@ enable_search = true
 
 ## Navigation
 header_nav = [
-  { url = "/", name_en = "/home/", name_fr = "/accueil/" },
+  { url = "/", name_en = "/home/", url_fr="/fr/", name_fr = "/accueil/" },
   { url = "/about", name_en = "/about/", name_fr = "/concernant/" },
   { url = "/journal", name_en = "/journal/", name_fr = "/journal/" },
-  { url = "/blog", name_en = "/blog/", name_fr = "/blog/" }
+  { url = "/blog", name_en = "/blog/", url_fr="/fr/blog", name_fr = "/blog/" }
 ]

--- a/content/blog/_index.fr.md
+++ b/content/blog/_index.fr.md
@@ -1,0 +1,7 @@
++++
+title = "All blog posts"
+paginate_by = 15
+sort_by = "date"
++++
+
+[🔖 List](/tags)

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,16 @@
         {% endif %}
         <nav id="nav-bar">
             {% for nav_item in config.extra.header_nav %}
-            <a href="{{ nav_item.url }}" class="{% if current_url is defined and nav_item.url == current_url %}active{% endif %}">
+            {% set item_url = nav_item.url %}
+            {% if current_lang != config.default_language %}
+                {% set lang_url_key = 'url_' ~ current_lang %}
+                {% if lang_url_key in nav_item %}
+                    {% set item_url = nav_item[lang_url_key] %}
+                {% else %}
+                    {% set item_url = nav_item.url %}
+                {% endif %}
+            {% endif %}
+            <a href="{{ item_url }}" class="{% if current_url is defined and item_url == current_url %}active{% endif %}">
                 {% set language_key = 'name_' ~ current_lang %}
                 {{ nav_item[language_key] }}
             </a>


### PR DESCRIPTION
I wanted to have a way to navigate pages with nav bar when switched to different language.
Now after switching to other language version of post, not only You can see proper language version of link name in nav bar but also after clicking you will be redirected to proper language version of that page (if it is defined in config).

For example:
Visiting homepage in EN.
Switching to FR (Nav bar names switch also to FR)
Clicking on blog redirects you to /fr/blog instead of /blog (as confgured in config)

This uses additional item key and value in header_nav: url_{langkey}.

Example site is working fine (added FR version of blog index page).